### PR TITLE
Add modern API send and receive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,22 @@ Text messaging script for Weechat using Google Voice
 ### Usage:
 
 1) Edit the script or ```~/.weechat/plugins.conf``` and input
-your credentials and desired poll interval.
+your credentials, api key and desired poll interval.
+
+[Retrieving your modern google voice API key](#API-Key)
 
 plugins.conf:
 
      python.weetext.email = "your_address@gmail.com"
      python.weetext.passwd = "${sec.data.weetext}"
      python.weetext.poll_interval = "120"
+     python.weetext.api_key= "<api_key>"
 
 or, if you don't want to use the /secure password storage
 in weechat:
 
      python.weetext.passwd = "mypasswd"
+
 
 Load the script and weechat should connect to Google Voice.
 Then after "polling_interval" seconds, you should see
@@ -49,6 +53,8 @@ the case for the crypt.py script
 This module is synchronized to work with the latest ```googlevoice``` package
 which can be retrieved via:
 
+It currently uses pygoogle voice to establish the login session
+
 ```bash
 pip install googlevoice
 ```
@@ -56,6 +62,28 @@ pip install googlevoice
 
 ### Todos:
 
-1. right now there aren't really any... ```;-)```
+1. Either: 
+  A) remove pygooglevoice dependency as it is only used for login now 
+  B) ideally, make necessary updates to pygoogle voice to wrap around new API
+
+* Figure out how to retrieve API key automatically. 
+
+### API-Key
+
+The simplest way to retreive the api key is to open the developer tools in your favorite browser
+and see the requests that it is sending when you are logged into google voice
+
+The latest google voice regularly polls and there will be plenty of requests with the api key
+in plain sight. See below examples:
+
+The simplest way is to go to the developer tools in your browser and to see the requests
+being sent. See screenshots below
+
+
+#### Chromium 71.0.3578.98 Arch Linux
+![chromium](https://user-images.githubusercontent.com/5562156/51813534-dec52400-2284-11e9-915e-913c2bd1c526.png)
+
+#### Mozilla Firefox 64.0.2
+![firefox](https://user-images.githubusercontent.com/5562156/51813542-e684c880-2284-11e9-95d2-c46e549f16a5.png)
 
 Enjoy!

--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ the case for the crypt.py script
 
 ### pygooglevoice Dependency
 
-In order for weetext to work, you need to install pygooglevoice.
-This can be problematic to find a version that works (Google changes
-thinks occasionally ;). I keep a working version at https://github.com/rxcomm/pygooglevoice
-This is the one I use.
+This module is synchronized to work with the latest ```googlevoice``` package
+which can be retrieved via:
+
+```bash
+pip install googlevoice
+```
+
 
 ### Todos:
 

--- a/weetext.py
+++ b/weetext.py
@@ -101,7 +101,7 @@ class Conversation(object):
 
     def new_messages(self, other):
         new_msg_ids = set(other.__messages.keys()) - set(self.__messages.keys())
-        return [other.__messages[k] for  k in new_msg_ids]
+        return [other.__messages[k] for k in other.__messages if k in new_msg_ids]
 
     def __iter__(self):
         return iter(reversed(self.messages))

--- a/weetext.py
+++ b/weetext.py
@@ -514,7 +514,7 @@ def send_sms(session, number, payload):
             # new messages go into the 6th index and are comma separated numbers
             # This only supports one message at the time and this plugin
             # iterates over the numbers anyway
-            body[6].append(new_number)
+            body[6].append(number)
         return body
 
 

--- a/weetext.py
+++ b/weetext.py
@@ -373,7 +373,7 @@ class SMS:
                     if msgitem["text"]:
                         msgitem["text"] = BeautifulStoneSoup(msgitem["text"],
                                           convertEntities=BeautifulStoneSoup.HTML_ENTITIES
-                                          ).contents[0]
+                                          ).contents[0].encode("ascii", "replace")
                         msgitem['phone'] = phone
                         smses.append(msgitem)
                 convos.append(Conversation(conversation['id'], phone, smses))
@@ -436,12 +436,14 @@ def send_sms(session, number, payload):
     # and relies on the current existing implementation in ```getsms```
 
     # In order to extract the headers, I messed around with the HTTP archive coming
-    # out of firefox and made various combinations of headers until I got this working
+    # out of firefox
 
-    # The body hack is just luck.
+    # The body expected:
     # * Index 4: The message body
     # * Index 5: The number identifier
     # * Index 6: Used for new numbers (does not have group or text prefix)
+
+    # Do not know what the other indices correspond to
 
     # The last index of the body is magic to me, I have no idea what it is. I could
     # not send out group sms until I wiped out that element. It was a random guess that

--- a/weetext.py
+++ b/weetext.py
@@ -405,7 +405,6 @@ if __name__ == '__main__':
         f.write("""#!/usr/bin/env python2
 
 import datetime
-import json
 import os
 import sys
 from hashlib import sha1
@@ -530,8 +529,8 @@ def send_sms(session, number, payload):
         if not res.ok:
             raise Exception(res.text)
 
-voice = Voice()
 try:
+    voice = Voice()
     voice.login(email, passwd)
     if api_key:
         send_sms(voice.session, number, payload)

--- a/weetext.py
+++ b/weetext.py
@@ -67,7 +67,6 @@ import subprocess
 import random
 import string
 from googlevoice import Voice
-from googlevoice.util import input
 from BeautifulSoup import BeautifulSoup, BeautifulStoneSoup, SoupStrainer
 
 script_options = {
@@ -308,7 +307,6 @@ import re
 import os
 import glob
 from googlevoice import Voice
-from googlevoice.util import input
 from BeautifulSoup import BeautifulSoup, BeautifulStoneSoup, SoupStrainer
 
 user_path = os.path.expanduser('~')
@@ -390,7 +388,7 @@ if __name__ == '__main__':
 import sys
 import os
 from googlevoice import Voice
-from googlevoice.util import input
+from six.moves import input
 
 # read the credentials, payload, and msg_id from stdin
 email = sys.stdin.readline().strip()


### PR DESCRIPTION
## Send / Receive SMS with new google voice API

The main inspiration for wrapping around the hidden modern google voice API is that this code allows one to be able to respond to group messages. 

* Send and retrieve sms with the new modern api 
* Add api_key config option for new google voice api key
  -Note: this is now a requirement. See screenshots at bottom for retreiving API key
* Improved response time for receiving sms
* Removed beautiful soup dependency

This plugin now supports responding to group texts: see screenshot below

![GroupMessage](https://user-images.githubusercontent.com/5562156/51812805-28ac0b00-2281-11e9-8458-77307b93155e.png)

Not being able to respond to group texts because of limitations of the pygooglevoice package was the inspiration for this update. 


## TODOS: 
* Either: 
  A) remove pygooglevoice dependency as it is only used for login now 
  B) ideally, make necessary updates to pygoogle voice to wrap around new API

* Figure out how to retrieve API key automatically. 

## Retrieving api key

The simplest way is to go to the developer tools in your browser and to see the requests
being sent. See screenshots below

#### Chromium 71.0.3578.98 Arch Linux
![chromium](https://user-images.githubusercontent.com/5562156/51813534-dec52400-2284-11e9-915e-913c2bd1c526.png)

#### Mozilla Firefox 64.0.2
![firefox](https://user-images.githubusercontent.com/5562156/51813542-e684c880-2284-11e9-95d2-c46e549f16a5.png)

@tych0 @rxcomm 
This is really just a proof of concept and I'd prefer to refactor this module a bit, but it does the job. You guys did some pretty complicated stuff with weechat that is still over my head so major kudos to you all. 